### PR TITLE
Add user login

### DIFF
--- a/migrations/1_create_users.js
+++ b/migrations/1_create_users.js
@@ -2,9 +2,9 @@ exports.up = function (knex) {
   return knex.schema
     .createTable('users', function (t) {
       t.increments('id');
-      t.string('password-hash');
-      t.string('slack-user-name').notNullable();
-      t.string('npm-user-name').notNullable();
+      t.string('slack-user-id').notNullable();
+      t.string('slack-team-id').notNullable();
+      t.string('npm-token-hashed');
     });
 };
 

--- a/seeds/0_users.js
+++ b/seeds/0_users.js
@@ -1,8 +1,8 @@
 exports.seed = function(knex, Promise) {
   return Promise.join(
     knex('users').insert({
-      'slack-user-name': 'ag_dubs',
-      'npm-user-name': 'ag_dubs'
+      'slack-user-id': '666',
+      'slack-team-id': '667'
     })
   );
 };

--- a/src/lib/hook_receiver.js
+++ b/src/lib/hook_receiver.js
@@ -1,4 +1,4 @@
-const makeReceiver = require("@npmcorp/npm-hook-receiver");
+const makeReceiver = require("npm-hook-receiver");
 
 // hook receiver is a restify server
 var opts = {

--- a/src/resources/subscriptions/helpers.js
+++ b/src/resources/subscriptions/helpers.js
@@ -45,8 +45,8 @@ module.exports = {
   },
   buildUser: function(userOpts, body) {
     return {
-      'slack-user-id': userOpts.json.user.id,
-      'slack-team-id': userOpts.json.team.id,
+      'slack-user-id': '666',
+      'slack-team-id': '667',
       'npm-token-hashed': body.token
     };
   }

--- a/src/resources/subscriptions/helpers.js
+++ b/src/resources/subscriptions/helpers.js
@@ -29,6 +29,13 @@ module.exports = {
       "type": hook_opts.json.type,
       "event": hook_opts.json.event
     }
+  },
+  buildUser: function(userOpts, body) {
+    return {
+      'slack-user-id': userOpts.json.user.id,
+      'slack-team-id': userOpts.json.team.id,
+      'npm-token-hashed': body.token
+    };
   }
 }
 

--- a/src/resources/subscriptions/helpers.js
+++ b/src/resources/subscriptions/helpers.js
@@ -1,12 +1,25 @@
 module.exports = {
   parseRequestBody: function (request) {
     var messages = request._body.split('&')[8].split('+');
-    return {
-      command: messages[0],
-      type: messages[1],
-      name: messages[2],
-      event: messages[3],
-      secret: messages[4]
+    var command = messages[0].replace("text=", "");
+    switch (command) {
+      case "login":
+        return {
+          command: command,
+          token: messages[1]
+        };
+      case "help":
+        return {
+          command: command
+        };
+      default:
+        return {
+          command: command,
+          type: messages[1],
+          name: messages[2],
+          event: messages[3],
+          secret: messages[4]
+        };
     }
   },
   buildHookRequestOpts: function(info) {

--- a/src/resources/subscriptions/messenger.js
+++ b/src/resources/subscriptions/messenger.js
@@ -9,5 +9,6 @@ module.exports = {
     return  'Subscription successfully created! Captain-Hook ID: ' + record.get('id') +
             ' Webhooks ID: ' + record.get('hook_id');
   },
-  bookshelfCreateError: 'ARRGH! Bookshelf error creating subscription'
+  bookshelfCreateError: 'ARRGH! Bookshelf error creating subscription',
+  loggedIn: 'You are logged in!'
 };

--- a/src/resources/subscriptions/routes/slack.js
+++ b/src/resources/subscriptions/routes/slack.js
@@ -34,7 +34,10 @@ const login = function(info) {
         require: false
       })
       .then(function(user){
-      //   overwrite token
+        if( user == null ){
+          throw new Error("User not found");
+        }
+        return user.set({'npm-token-hashed': info.token}).save();
       })
       .catch(function(){
         var userOpts = helpers.buildUser(opts, body);

--- a/src/resources/subscriptions/routes/slack.js
+++ b/src/resources/subscriptions/routes/slack.js
@@ -14,6 +14,42 @@ const opts = {
   username: "captainhook"
 };
 
+const login = function(info) {
+  // grab token + username + team id (we don't have this yet)
+  // anything missing? (would be the token, likely)
+  //    give feedback
+  //
+  // is token invalid?
+  var opts = {
+    uri:'https://registry.npmjs.com/-/whoami',
+    auth: { bearer: info.token },
+  };
+  return Request.get(opts, function(err, res, body){
+    if(res.statusCode === 401) {
+      //return feedback
+    }
+
+    return User.where('token', info.token)
+      .fetch()
+      .then(function(user){
+      //   overwrite token
+      })
+      .catch(function(){
+        let userOpts = helpers.buildUser(opts, body);
+        return User.forge(userOpts).save();
+      })
+      .finally(function(){
+    // give feedback that user is created/logged in
+      });
+    //
+  });
+};
+
+const logout = function(info) {
+  // delete token
+  // kill notifications
+};
+
 var subscribe = function(info) { 
   var hook_opts = helpers.buildHookRequestOpts(info);
   Request.post(hook_opts, function(err, res, body) {
@@ -96,6 +132,9 @@ module.exports = function(request, response, next) {
   var command = info.command.slice(5);
   var message;
   switch(command) {
+    case "login":
+      login(info);
+      break;
     case "subscribe":
       subscribe(info);
       break;

--- a/src/resources/subscriptions/routes/slack.js
+++ b/src/resources/subscriptions/routes/slack.js
@@ -22,7 +22,7 @@ const login = function(info) {
   // is token invalid?
   var opts = {
     uri:'https://registry.npmjs.com/-/whoami',
-    auth: { bearer: info.token },
+    auth: { bearer: info.token }
   };
   return Request.get(opts, function(err, res, body){
     if(res.statusCode === 401) {

--- a/src/resources/subscriptions/routes/slack.js
+++ b/src/resources/subscriptions/routes/slack.js
@@ -127,7 +127,10 @@ var help = function() {
          "\t\t*command*: `subscribe` (create a new webhook), `help`, `list`\n" +
          "\t\t*type*: `package` or `scope`\n" +
          "\t\t*name*: the name of the package or scope, e.g. `lodash`\n" +
-         "\t\t*event*: this doesn't actually work yet :grimacing: :sweat_smile:\n";
+         "\t\t*event*: this doesn't actually work yet :grimacing: :sweat_smile:\n" +
+         "\n" +
+         "\n" +
+         "/captain-hook login <token>";
 
   slack.chat.postMessage(channelID, message, slackOpts);
 };

--- a/src/resources/subscriptions/routes/slack.js
+++ b/src/resources/subscriptions/routes/slack.js
@@ -129,9 +129,7 @@ var help = function() {
 // receive outgoing integration from slack `/captain-hook`
 module.exports = function(request, response, next) {
   var info = helpers.parseRequestBody(request);
-  var command = info.command.slice(5);
-  var message;
-  switch(command) {
+  switch(info.command) {
     case "login":
       login(info);
       break;

--- a/src/resources/subscriptions/routes/slack.js
+++ b/src/resources/subscriptions/routes/slack.js
@@ -35,7 +35,7 @@ const login = function(info) {
       //   overwrite token
       })
       .catch(function(){
-        let userOpts = helpers.buildUser(opts, body);
+        var userOpts = helpers.buildUser(opts, body);
         return User.forge(userOpts).save();
       })
       .finally(function(){

--- a/src/resources/subscriptions/routes/slack.js
+++ b/src/resources/subscriptions/routes/slack.js
@@ -15,18 +15,13 @@ const slackOpts = {
 };
 
 const login = function(info) {
-  // grab token + username + team id (we don't have this yet)
-  // anything missing? (would be the token, likely)
-  //    give feedback
-  //
-  // is token invalid?
   var opts = {
     uri:'https://registry.npmjs.com/-/whoami',
     auth: { bearer: info.token }
   };
   return Request.get(opts, function(err, res, body){
     if(res.statusCode === 401) {
-      //return feedback
+      slack.chat.postMessage(channelID, body, slackOpts);
     }
 
     return User.where('npm-token-hashed', info.token)
@@ -46,13 +41,11 @@ const login = function(info) {
       .finally(function(){
         slack.chat.postMessage(channelID, messenger.loggedIn, slackOpts);
       });
-    //
   });
 };
 
 const logout = function(info) {
-  // delete token
-  // kill notifications
+  // this is waiting on Slack App Integration
 };
 
 var subscribe = function(info) { 

--- a/src/resources/subscriptions/routes/slack.js
+++ b/src/resources/subscriptions/routes/slack.js
@@ -29,8 +29,10 @@ const login = function(info) {
       //return feedback
     }
 
-    return User.where('token', info.token)
-      .fetch()
+    return User.where('npm-token-hashed', info.token)
+      .fetch({
+        require: false
+      })
       .then(function(user){
       //   overwrite token
       })


### PR DESCRIPTION
fixes #3 and #8

This will add a user login method. It will also involve a user logout method.

Some notes:

Commands:
`/captain-hook login [token]`
- What feedback do we give here?
- User identity + team id will need to be stored as that is guaranteed to be unique

`/captain-hook logout`
- Maybe used when somebody wants to refresh auth?
- or maybe they just don't want the noise
- Delete all subscriptions at that point? No
- Just don't send notifications


If not logged in, what happens when somebody /captain-hook subscribe?
- Give feedback to login
